### PR TITLE
chore(version):  Bump version and appVersion for new agent. (#24)

### DIFF
--- a/charts/katie-agent/Chart.yaml
+++ b/charts/katie-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.13
+version: 0.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: main.e4aa4691.v137
+appVersion: main.1c41f940.v141


### PR DESCRIPTION
- The agent can now use the Kubelet API directly to retrieve node and pod metrics.