### PR TITLE
Chart 0.0.15

### DIFF
--- a/charts/katie-agent/Chart.yaml
+++ b/charts/katie-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.14
+version: 0.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: main.1c41f940.v141
+appVersion: main.8479ee95.v143


### PR DESCRIPTION
- (Agent, API, Registry) Adds a `truncate` flag to agent responses which have been truncated to protect the LLM conversation history from becoming too long
- (API) Adds better handling for errors from the LangGraph LLM node
- (API) Restores custom error reporting back to the chat (regressed during the conversion to chunking)